### PR TITLE
add step to copy CNAME into _docs 

### DIFF
--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -43,6 +43,10 @@ runs:
         except Exception as e: 
           print(f'::error title="Could not enable GitHub Pages Automatically":: {msg}\n{e}')
           sys.exit(1)
+    - name: copy CNAME file into _docs if CNAME exists
+      run: |
+        sudo chmod -R 777 _docs/
+        cp CNAME _docs/ 2>/dev/null || :
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -44,6 +44,7 @@ runs:
           print(f'::error title="Could not enable GitHub Pages Automatically":: {msg}\n{e}')
           sys.exit(1)
     - name: copy CNAME file into _docs if CNAME exists
+      shell: bash
       run: |
         sudo chmod -R 777 _docs/
         cp CNAME _docs/ 2>/dev/null || :


### PR DESCRIPTION
Adds a step to the [quarto-ghp action](quarto-ghp/action.yml) which copies the `CNAME` file into the `_docs` directory if it exists. 

Adapted from the [fastpages ci workflow](https://github.com/fastai/fastpages/blob/master/.github/workflows/ci.yaml#:~:text=%2D%20name%3A%20copy%20CNAME,CNAME%20_site/%202%3E/dev/null%20%7C%7C%20%3A).

fixes fastai/nbdev#1033.


