### PR TITLE
bump version number of setup-python action

### DIFF
--- a/.github/workflows/test_broken_links.yaml.off
+++ b/.github/workflows/test_broken_links.yaml.off
@@ -10,7 +10,7 @@ on: [workflow_dispatch]
 #       - uses: actions/checkout@master
 #         with:
 #           repository: 'fastai/fastlinkcheck'  
-#       - uses: actions/setup-python@v2
+#       - uses: actions/setup-python@v4
 #       - name: check for broken links
 #         run: |
 #           pip install fastlinkcheck
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: 'fastai/fastlinkcheck'  
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
       - name: check for broken links
         id: links
         uses: fastai/workflows/broken_links@master
@@ -67,7 +67,7 @@ jobs:
 #     runs-on: ubuntu-latest
 #     name: test-open-issue
 #     steps:
-#     - uses: actions/setup-python@v2
+#     - uses: actions/setup-python@v4
 #     - uses: fastai/workflows/open_issue@master
 #       id: open_issue
 #       with:

--- a/.github/workflows/test_open_issue.yaml
+++ b/.github/workflows/test_open_issue.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test-open-issue
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - uses: fastai/workflows/open_issue@master
       id: open_issue
       with:

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps: 
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}
         cache: "pip"

--- a/open_issue/README.md
+++ b/open_issue/README.md
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test-open-issue
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - uses: fastai/workflows/open_issue@master
       id: open_issue
       with:

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps: 
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
     - name: Install Dependencies
       env:
         USE_PRE: ${{ inputs.pre }}

--- a/quarto-rsync/action.yml
+++ b/quarto-rsync/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps: 
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
     - name: Install deps, build docs, and sync
       env:
         SSH_KEY: ${{ inputs.ssh_key }}


### PR DESCRIPTION
While working on a fresh nbdev-template, I noticed the following warning.
```
Run actions/setup-python@v3
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Successfully setup CPython (3.9.15)
```
I am guessing that bumping up `setup-python` to v4 will fix the problem. AFAIK, such version upgrades are backward compatible, but I'm not sure how to test all the actions.

While I was at it, I bumped up all the 'v2' and 'v3' tags (not just nbdev_ci) including those in comments and readme files.

I'm very far from being a github actions expert, but I think these version bumps should be safe, even though I haven't tested them.