### PR TITLE
Update error message to provide instructions to install newest nbdev

### DIFF
--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -59,6 +59,7 @@ runs:
         if [[ `git status --porcelain -uno` ]]; then
           git status -uno
           echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_hooks"
+          echo -e "This error can also happen if you are using an different version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U git+https://github.com/fastai/nbdev.git`"
           false
         fi
         nbdev_export

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -59,7 +59,7 @@ runs:
         if [[ `git status --porcelain -uno` ]]; then
           git status -uno
           echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_hooks"
-          echo -e "This error can also happen if you are using an older version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U git+https://github.com/fastai/nbdev.git`"
+          echo -e "This error can also happen if you are using an older version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U nbdev`"
           false
         fi
         nbdev_export

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -59,7 +59,7 @@ runs:
         if [[ `git status --porcelain -uno` ]]; then
           git status -uno
           echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_hooks"
-          echo -e "This error can also happen if you are using an different version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U git+https://github.com/fastai/nbdev.git`"
+          echo -e "This error can also happen if you are using an older version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U git+https://github.com/fastai/nbdev.git`"
           false
         fi
         nbdev_export


### PR DESCRIPTION
I am actually unsure about this change.  It feels wrong to advise people to install the bleeding edge nbdev to resolve an error?  But maybe it is ok?