### PR TITLE
Enable LFS and custom token

### DIFF
--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -17,11 +17,22 @@ inputs:
     description: 'Space separated list of nbdev test flags to run that are normally ignored'
     required: false
     default: ''
+  lfs:
+    description: 'Enable Git LFS?'
+    required: false
+    default: 'false'
+  token:
+    description: 'GitHub token'
+    required: false
+    default: '${{ github.token }}'
 
 runs:
   using: "composite"
   steps: 
     - uses: actions/checkout@v3
+      with:
+        lfs: "${{ inputs.lfs }}"  
+        token: "${{ inputs.token }}"
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}


### PR DESCRIPTION
**Why a custom token?**
A CI workflow that bumps the project version with `nbdev_bump_version` on every CI build fails without a custom token.

**Why LFS?**
Tests that involve loading big datasets saved in the repository fail without this flag.

# Alternative solution

Have a flag that skips the git checkout step, and lets the workflow using `fastai/workflow` implement its own github checkout step with any custom values