### PR TITLE
Add prod_editable_install option to CI pipeline for testing without dev extras

### DIFF
--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Skip tests?'
     required: false
     default: ''
+  prod_editable_install:
+    description: 'Use editable install without dev extras?'
+    required: false
+    default: 'false'
   flags:
     description: 'Space separated list of nbdev test flags to run that are normally ignored'
     required: false
@@ -31,6 +35,7 @@ runs:
       env:
         USE_PRE: ${{ inputs.pre }}
         SKIP_TEST: ${{ inputs.skip_test }}
+        PROD_EDITABLE_INSTALL: ${{ inputs.prod_editable_install }}
         FLAGS: ${{ inputs.flags }}
       shell: bash
       run: |
@@ -45,7 +50,11 @@ runs:
           pip install -U nbdev
         fi
         echo "Doing editable install..."
-        test -f setup.py && pip install -e ".[dev]"
+        if [ $PROD_EDITABLE_INSTALL == "true" ]; then
+          test -f setup.py && pip install -e "."
+        else
+          test -f setup.py && pip install -e ".[dev]"
+        fi
         echo "Check we are starting with clean git checkout"
         if [[ `git status --porcelain -uno` ]]; then
           git diff


### PR DESCRIPTION
This pull request introduces a new option called `prod_editable_install` to the CI pipeline. This option allows us to test the application in an environment similar to the production environment by installing only the main dependencies without the development extras.

By setting `prod_editable_install` to `true`, the CI pipeline will use `pip install -e .` instead of `pip install -e .[dev]`. This helps us automatically catch errors related to missing production dependencies and ensures that our application runs smoothly in production.

Here's a summary of the changes made in this PR:

1. Added a new input called `prod_editable_install` to the GitHub Action.
2. Updated the `Test with nbdev` section to conditionally use `pip install -e .` or `pip install -e .[dev]` based on the value of `prod_editable_install`.

Please review the changes and let me know if you have any questions or suggestions.