### PR TITLE
Add publish_branch input to quarto-ghp action

### DIFF
--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'GitHub token'
     default: ${{ github.token }}
     required: false
+  publish_branch:
+    description: 'Branch name to publish docs to'
+    required: false
+    default: 'gh-pages'
 
 runs:
   using: "composite"
@@ -52,4 +56,4 @@ runs:
         # You can swap them out with your own user credentials.
         user_name: github-actions[bot]
         user_email: 41898282+github-actions[bot]@users.noreply.github.com
-
+        publish_branch: ${{ inputs.publish_branch }}

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -57,3 +57,4 @@ runs:
         user_name: github-actions[bot]
         user_email: 41898282+github-actions[bot]@users.noreply.github.com
         publish_branch: ${{ inputs.publish_branch }}
+


### PR DESCRIPTION
The quarto-ghp action uses `peaceiris/actions-gh-pages` to commit the built docs inside `_docs/` to the `gh-pages` branch. In 99% of cases this is the only branch that makes sense to push the docs to, because this is the only branch that GitHub turns into a GitHub Pages website automatically. However, it may be relevant to push built docs to a different branch in some contexts, for example to create "PR previews" for the docs that show what the `gh-pages` branch would look like if a PR was merged. If we could control the branch name that will be pushed to, we could push preview branch docs to `gh-pages-{branchname}` for example. The downside is that GitHub will not automatically turn these branches into GitHub Pages websites, but there may be alternative ways to view the built site on the preview branch (e.g. via a proxy that could serve the repo content like [sclabs/ghp-proxy](https://github.com/sclabs/private-ghp) - disclosure: I am the author/maintainer and this may not be a valid way to serve content in a production context).

The `peaceiris/actions-gh-pages` decides what branch to push to using the `publish_branch` input ([docs](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-another-github-pages-branch-publish_branch)). Before this PR, the quarto-ghp action did not pass `publish_branch` to `peaceiris/actions-gh-pages` (so it always gets the default value `gh-pages`) and there was no way to override it from the quarto-ghp action. This PR adds `publish_branch` as a new input to the quarto-ghp action (setting it as not required and defaulting to `ghp-pages`) and passes it through to `peaceiris/actions-gh-pages`.

Sorry to open a PR without a pre-existing issue or discussion and feel free to close if the 1% use case is not worth the code change and extra complexity.