### PR TITLE
Slim nbdev actions by defaulting to PyTorch-CPU Install

### DIFF
--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -11,28 +11,38 @@ inputs:
     description: 'path to rsync to'
     required: true
   ssh_key:
-    description: "SSH key for rsync" 
+    description: "SSH key for rsync"
     required: true
   delete:
     description: "Toggle the --delete flag on or off for rsync.  Set to any value to enable.  Disabled by default."
     required: false
     default: ''
+  torch_cpu:
+    description: "Install PyTorch CPU instead of PyTorch Cuda.  Has no effect if PyTorch isn't a requirement.  Enabled by defaut."
+    required: false
+    default: true
+
 runs:
   using: "composite"
-  steps: 
+  steps:
     - name: Create docs
       shell: bash
       env:
         JEKYLL_ENV: 'production'
         SSH_KEY: ${{ inputs.ssh_key }}
         delete: "${{ inputs.delete }}"
+        TORCH_CPU: "${{ inputs.torch_cpu }}"
       run: |
         cp -r docs_src docs
         pip install -Uq nbdev fastcore
-        pip install -Uq -e .[dev]
+        if [ $TORCH_CPU ]; then
+          pip install -Uq -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
+        else
+          pip install -Uq -e .[dev]
+        fi
         pip install -U 'jupyter_client<7'
         nbdev_build_docs
-        cd docs 
+        cd docs
         bundle i
         bundle exec jekyll build --strict_front_matter
         echo "$SSH_KEY" > ~/.ssh/id_rsa

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -17,10 +17,14 @@ inputs:
     description: 'Space separated list of nbdev test flags to run that are normally ignored'
     required: false
     default: ''
+  torch_cpu:
+    description: "Install PyTorch CPU instead of PyTorch Cuda.  Has no effect if PyTorch isn't a requirement.  Enabled by defaut."
+    required: false
+    default: true
 
 runs:
   using: "composite"
-  steps: 
+  steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -32,6 +36,7 @@ runs:
         USE_PRE: ${{ inputs.pre }}
         SKIP_TEST: ${{ inputs.skip_test }}
         FLAGS: ${{ inputs.flags }}
+        TORCH_CPU: "${{ inputs.torch_cpu }}"
       shell: bash
       run: |
         set -ux
@@ -45,7 +50,11 @@ runs:
           pip install -U nbdev
         fi
         echo "Doing editable install..."
-        test -f setup.py && pip install -e ".[dev]"
+        if [ $TORCH_CPU ]; then
+          test -f setup.py && pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+        else
+          test -f setup.py && pip install -e ".[dev]"
+        fi
         echo "Check we are starting with clean git checkout"
         if [[ `git status --porcelain -uno` ]]; then
           git diff

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'GitHub token'
     default: ${{ github.token }}
     required: false
+  torch_cpu:
+    description: "Install PyTorch CPU instead of PyTorch Cuda.  Has no effect if PyTorch isn't a requirement.  Enabled by defaut."
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -26,6 +30,7 @@ runs:
     - name: Install Dependencies
       env:
         USE_PRE: ${{ inputs.pre }}
+        TORCH_CPU: "${{ inputs.torch_cpu }}"
       shell: bash
       run: |
         set -ux
@@ -40,7 +45,11 @@ runs:
         else
           pip install -Uq nbdev
         fi
-        test -f setup.py && pip install -e ".[dev]"
+        if [ $TORCH_CPU ]; then
+          test -f setup.py && pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+        else
+          test -f setup.py && pip install -e ".[dev]"
+        fi
         nbdev_docs
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3

--- a/quarto-rsync/action.yml
+++ b/quarto-rsync/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'path to rsync to'
     required: true
   ssh_key:
-    description: "SSH key for rsync" 
+    description: "SSH key for rsync"
     required: true
   delete:
     description: "Toggle the --delete flag on or off for rsync.  Set to any value to enable.  Disabled by default."
@@ -21,9 +21,14 @@ inputs:
     description: 'Install prerelease nbdev/execnb from master?'
     required: false
     default: ''
+  torch_cpu:
+    description: "Install PyTorch CPU instead of PyTorch Cuda.  Has no effect if PyTorch isn't a requirement.  Enabled by defaut."
+    required: false
+    default: true
+
 runs:
   using: "composite"
-  steps: 
+  steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - name: Install deps, build docs, and sync
@@ -31,6 +36,7 @@ runs:
         SSH_KEY: ${{ inputs.ssh_key }}
         USE_PRE: ${{ inputs.pre }}
         delete: "${{ inputs.delete }}"
+        TORCH_CPU: "${{ inputs.torch_cpu }}"
       run: |
         mkdir -p ~/.ssh
         chmod 700 ~/.ssh
@@ -45,7 +51,11 @@ runs:
         else
           pip install -U nbdev
         fi
-        pip install -e ".[dev]"
+        if [ $TORCH_CPU ]; then
+          pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+        else
+          pip install -e ".[dev]"
+        fi
         nbdev_docs
         rsync $(echo ${delete:+'--delete'}) -az _docs/ ${{ inputs.username }}@${{ inputs.hostname }}:${{ inputs.dest_path }}/
       shell: bash


### PR DESCRIPTION
This PR modifies all nbdev related actions which install from source `pip install -e ".[dev]"` to default to installing PyTorch-CPU instead of PyTorch-Cuda. Removing Cuda dependencies by default decreases cache sizes by ~2GB.

To control the version of PyTorch installed, this PR adds the `torch_cpu` input. When set to false nbdev actions install the default version of PyTorch (Cuda).

This PR has no effect if PyTorch is not a package requirement.