### PR TITLE
Add skip_checkout option to nbdev-ci

### DIFF
--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -21,11 +21,16 @@ inputs:
     description: "Install PyTorch CPU instead of PyTorch Cuda.  Has no effect if PyTorch isn't a requirement.  Enabled by defaut."
     required: false
     default: true
+  skip_checkout:
+    description: "Skip checkout of repo.  Useful when the repo checkout needs to be customized by the calling workflow."
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
+      if: ${{ inputs.skip_checkout != 'true' }}
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}


### PR DESCRIPTION
tl;dr: Add a flag to the `nbdev-ci` action to allow skipping checkout of the repo. This allows calling workflows to customize the checkout if needed. I tested thoroughly. It's a small change but I wanted to provide a lot of context below because this is my first PR in this repo. I love nbdev and thanks for all the work on it. 

# Context
In some situations, it's necessary to customize the way the repo is checked out in order for tests to run successfully. In my case, I need this because my tests rely on some files that live in [Git LFS](https://git-lfs.com/) and I needed to pull those files from LFS after the repo was checked out and before tests run. AFAICT, there's no good way to do this with `nbdev-ci` today because it does the repo checkout as the first action, with no options to customize it. 

Others seem to want this too e.g.  PR https://github.com/fastai/workflows/pull/69 adds an enable_lfs flag, and issue https://github.com/fastai/workflows/issues/62 asks about support for DVC, which is an alternate to LFS. 

# Proposed Solution
Rather than try to customize `nbdev-ci` to handle every forseeable option, this PR proposes to add a `skip_checkout` flag that, when true, skips the checkout step within `nbdev-ci`. The calling workflow would then be able to (actually, have to) perform the checkout and pass any needed flags or perform extra steps. I note that https://github.com/fastai/workflows/issues/62 suggested this as an alternate approach. 

> Note: I pass the default value of the flag as a string, and then test against strings `'true'` and `'false`' because per the [JSON schema for GitHub actions](https://json.schemastore.org/github-action.json) and discussed [here](https://stackoverflow.com/a/76294014/490982) and [here](https://github.com/actions/runner/issues/1483), the default value for inputs is always a string. I noticed that the existing option `torch_cpu` doesn't do it that way - I don't have enough context to know if that's a problem but thought I'd point it out. 

# Tests
I created a dummy repo (https://github.com/spather/nbdev-test) with a basic nbdev project (just the result of `nbdev_new`) and added [workflow jobs](https://github.com/spather/nbdev-test/blob/master/.github/workflows/test.yaml) that test the various uses of the flag:

```yaml
name: CI
on:  [workflow_dispatch, pull_request, push]

jobs:
  # Test the upstream version of nbdev-ci as baseline
  test-upstream:
    runs-on: ubuntu-latest
    steps: [uses: fastai/workflows/nbdev-ci@master]

  # Test the master branch of my fork
  # (should be the same as upstream)
  test-fork-master:
    runs-on: ubuntu-latest
    steps: [uses: spather/fastai-workflows/nbdev-ci@master]

  # Test the skip-checkout branch of my fork
  # without specifying a value for skip_checkout
  # flag. Should be the same as setting it to 'false'.
  test-fork-branch-option-not-specified:
    runs-on: ubuntu-latest
    steps:
    - uses: spather/fastai-workflows/nbdev-ci@skip-checkout

  # Test the skip-checkout branch of my fork
  # with value set explicitly to 'false'
  test-fork-branch-explicit-false:
    runs-on: ubuntu-latest
    steps:
    - uses: spather/fastai-workflows/nbdev-ci@skip-checkout
      with:
        skip_checkout: 'false'

  # Test the skip-checkout branch of my fork
  # with value set explicitly to 'true'
  test-fork-branch-explicit-true:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v3 # Needed to because skip_checkout is true below
    - uses: spather/fastai-workflows/nbdev-ci@skip-checkout
      with:
        skip_checkout: 'true'
```

These all pass:
![Screen Shot 2023-10-03 at 2 22 16 PM](https://github.com/fastai/workflows/assets/476541/4cd573c2-e534-4f52-8bf4-4d47376c81da)

I examined the logs (see https://github.com/spather/nbdev-test/actions/runs/6398552289) and verified that the right thing happened in each case. Basically:
* `test-fork-branch-explicit-true` runs a separate checkout step and then runs the rest of nbdev-ci without its checkout step
* Everything else runs nbdev-ci as normal.


