### PR TITLE
build: update actions for latest Node version

### DIFF
--- a/.github/workflows/test_open_issue.yaml
+++ b/.github/workflows/test_open_issue.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test-open-issue
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
     - uses: fastai/workflows/open_issue@master
       id: open_issue
       with:
@@ -20,6 +20,6 @@ jobs:
         skip_if_exists_flag: ${{ matrix.skip }}
     - name: check outputs
       run: |
-        echo bool_new_issue_created ${{ steps.open_issue.outputs.bool_new_issue_created }} 
+        echo bool_new_issue_created ${{ steps.open_issue.outputs.bool_new_issue_created }}
         echo related_issue_num ${{ steps.open_issue.outputs.related_issue_num }}
-        echo related_issue_url ${{ steps.open_issue.outputs.related_issue_url }} 
+        echo related_issue_url ${{ steps.open_issue.outputs.related_issue_url }}

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.skip_checkout != 'true' }}
     - uses: actions/setup-python@v4
       with:

--- a/nbdev-ci/action.yml
+++ b/nbdev-ci/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
       if: ${{ inputs.skip_checkout != 'true' }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.version }}
         cache: "pip"

--- a/open_issue/README.md
+++ b/open_issue/README.md
@@ -23,11 +23,11 @@ inputs:
     description: 'Setting this to any value will result in not an opening a new issue if there is an existing issue with the same title.'
     required: false
 outputs:
-  bool_new_issue_created: 
+  bool_new_issue_created:
     description: "Returns 'True' or 'False' depending on if new issue was created.  Can only be 'False' if input skip_if_exists_flag is specified."
-  related_issue_num: 
+  related_issue_num:
     description: "Returns issue number of issue that was created.  If a new issue is not created because of the skip_if_exists_flag, the issue number of corresponding existing issue is returned."
-  related_issue_url: 
+  related_issue_url:
     description: "Same as related_issue_num except returns the URL for the issue instead of the issue number."
 ```
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test-open-issue
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
     - uses: fastai/workflows/open_issue@master
       id: open_issue
       with:
@@ -56,7 +56,7 @@ jobs:
         skip_if_exists_flag: "Yes" # omit this input completely if you do not want to trigger this flag
     - name: see outputs
       run: |
-        echo bool_new_issue_created ${{ steps.open_issue.outputs.bool_new_issue_created }} 
+        echo bool_new_issue_created ${{ steps.open_issue.outputs.bool_new_issue_created }}
         echo related_issue_num ${{ steps.open_issue.outputs.related_issue_num }}
-        echo related_issue_url ${{ steps.open_issue.outputs.related_issue_url }} 
+        echo related_issue_url ${{ steps.open_issue.outputs.related_issue_url }}
 ```

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}

--- a/quarto-ghp/action.yml
+++ b/quarto-ghp/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.version }}
         cache: "pip"

--- a/quarto-rsync/action.yml
+++ b/quarto-rsync/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
     - name: Install deps, build docs, and sync
       env:
         SSH_KEY: ${{ inputs.ssh_key }}

--- a/quarto-rsync/action.yml
+++ b/quarto-rsync/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
     - name: Install deps, build docs, and sync
       env:


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Example:
https://github.com/fastai/fastai/actions/runs/10170824148